### PR TITLE
Phase3 failure fix

### DIFF
--- a/ewxb
+++ b/ewxb
@@ -86,7 +86,7 @@ phase_0() {
 			svn checkout svn://gcc.gnu.org/svn/gcc/branches/gccgo gccgo
 			cd $GCCV
 			contrib/download_prerequisites
-            cd $SRC
+			cd $SRC
 		fi
 	else
 		if ! [ -f "$GCCV.tar.bz2" ]; then
@@ -97,7 +97,7 @@ phase_0() {
 			tar xvjf $GCCV.tar.bz2
 			cd $GCCV
 			contrib/download_prerequisites
-            cd $SRC
+			cd $SRC
 		fi
 	fi
 

--- a/ewxb
+++ b/ewxb
@@ -86,6 +86,7 @@ phase_0() {
 			svn checkout svn://gcc.gnu.org/svn/gcc/branches/gccgo gccgo
 			cd $GCCV
 			contrib/download_prerequisites
+            cd $SRC
 		fi
 	else
 		if ! [ -f "$GCCV.tar.bz2" ]; then
@@ -96,6 +97,7 @@ phase_0() {
 			tar xvjf $GCCV.tar.bz2
 			cd $GCCV
 			contrib/download_prerequisites
+            cd $SRC
 		fi
 	fi
 


### PR DESCRIPTION
Hey Erik! I found an issue in the "$GCCV/contrib/download_prerequisites" section of phase 0, causing a failure in phase 3. It looks like we cd into $GCCV to do the prereq download there, but then don't cd out again to wget linux and glibc. Instead we wget linux and glibc inside $GCCV. This means that in phase 3 (line 182), when we try to do a copy, it fails.

My change just backs out of $GCCV after running $GCCV/contrib/download_prerequisites in phase 0.
